### PR TITLE
Allow a fee-free art show

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -316,12 +316,13 @@ if c.ART_SHOW_ENABLED:
         ident='art_show_payment_received'
     )
 
-    ArtShowAppEmailFixture(
-        'Reminder to pay for your {EVENT_NAME} Art Show application',
-        'art_show/payment_reminder.txt',
-        lambda a: a.status == c.APPROVED and a.is_unpaid,
-        when=days_between((14, c.ART_SHOW_PAYMENT_DUE), (1, c.EPOCH)),
-        ident='art_show_payment_reminder')
+    if c.ART_SHOW_HAS_FEES:
+        ArtShowAppEmailFixture(
+            'Reminder to pay for your {EVENT_NAME} Art Show application',
+            'art_show/payment_reminder.txt',
+            lambda a: a.status == c.APPROVED and a.is_unpaid,
+            when=days_between((14, c.ART_SHOW_PAYMENT_DUE), (1, c.EPOCH)),
+            ident='art_show_payment_reminder')
 
     ArtShowAppEmailFixture(
         '{EVENT_NAME} Art Show piece entry needed',
@@ -341,7 +342,8 @@ if c.ART_SHOW_ENABLED:
         '{EVENT_NAME} Art Show MAIL IN Instructions',
         'art_show/mailing_in.html',
         lambda a: a.status == c.APPROVED and not a.is_unpaid and a.delivery_method == c.BY_MAIL,
-        when=days_between((c.ART_SHOW_REG_START, 13), (16, c.ART_SHOW_WAITLIST)),
+        when=days_between((c.ART_SHOW_REG_START, 13),
+                          (16, c.ART_SHOW_WAITLIST if c.ART_SHOW_WAITLIST else c.ART_SHOW_DEADLINE)),
         ident='art_show_mail_in')
 
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -381,6 +381,10 @@ class Config(_Overridable):
     @property
     def ART_SHOW_OPEN(self):
         return self.AFTER_ART_SHOW_REG_START and self.BEFORE_ART_SHOW_DEADLINE
+    
+    @property
+    def ART_SHOW_HAS_FEES(self):
+        return c.COST_PER_PANEL or c.COST_PER_TABLE or c.ART_MAILING_FEE
 
     @property
     def SELF_SERVICE_REFUNDS_OPEN(self):

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -175,7 +175,7 @@ mits_enabled = boolean(default=False)
 mivs_enabled = boolean(default=False)
 panels_enabled = boolean(default=False)
 badge_printing_enabled = boolean(default=False)
-art_show_enabled = boolean(default=False) # NOTE: Currently incompatible with discount promo codes.
+art_show_enabled = boolean(default=False)
 
 # Many events charge a fee for badge reprints. This controls how much that costs, in dollars.
 badge_reprint_fee = integer(default=0)
@@ -1046,7 +1046,7 @@ marketplace_payment_due     = string(default="")
 
 # These are similar to the dealer dates, but for Art Show applications.
 art_show_reg_start = string(default="2017-01-01")
-art_show_waitlist = string(default="2017-10-10")
+art_show_waitlist = string(default="")
 art_show_deadline = string(default="2017-10-10")
 art_show_payment_due = string(default="2017-10-10")
 

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -41,7 +41,7 @@ class Root:
 
             message = message or check(attendee) or check(app, prereg=True)
             if not message:
-                if c.AFTER_ART_SHOW_WAITLIST:
+                if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST:
                     app.status = c.WAITLISTED
                 session.add(attendee)
                 app.attendee = attendee

--- a/uber/templates/art_show_admin/form.html
+++ b/uber/templates/art_show_admin/form.html
@@ -37,7 +37,7 @@ app, c.PAGE_PATH,
 
       {% if new_app or c.HAS_ART_SHOW_ADMIN_ACCESS %}
       <div class="form-group">
-        <label for="attendee" class="col-sm-3 control-label">Attendee</label>
+        <label for="attendee" class="col-sm-3 form-text">Attendee</label>
         <div class="col-sm-6">
           <select class="form-select" id="attendee_id" name="attendee_id" required="true">
             <option value="" selected="selected">Select an attendee</option>
@@ -47,7 +47,7 @@ app, c.PAGE_PATH,
       </div>
       {% else %}
       <div class="form-group">
-        <label for="attendee" class="col-sm-3 control-label">Attendee Badge Status</label>
+        <label for="attendee" class="col-sm-3 form-text">Attendee Badge Status</label>
         <div class="col-sm-6">
           <select class="form-select" id="badge_status" name="badge_status">
             {{ options(c.BADGE_STATUS_OPTS, app.attendee.badge_status) }}
@@ -57,7 +57,7 @@ app, c.PAGE_PATH,
       {% endif %}
 
       <div class="form-group">
-        <label for="status" class="col-sm-3 control-label">Application Status</label>
+        <label for="status" class="col-sm-3 form-text">Application Status</label>
         <div class="col-sm-6">
           <select class="form-select" name="status">
             {{ options(c.ART_SHOW_STATUS_OPTS, app.status) }}
@@ -68,8 +68,9 @@ app, c.PAGE_PATH,
       </div>
 
       <div class="row g-3 form-group">
+        {% if c.ART_SHOW_HAS_FEES %}
         <div class="col-12 col-sm-6">
-          <label class="col-12 control-label">Paid?</label>
+          <label class="col-12 form-text">Paid?</label>
           <div class="col-12">
             {% if app.status == c.APPROVED %}
             <div class="form-inline">
@@ -84,8 +85,9 @@ app, c.PAGE_PATH,
             {% endif %}
           </div>
         </div>
+        {% endif %}
         <div class="col-12 col-sm-6">
-          <label class="col-12 control-label">Payout Method</label>
+          <label class="col-12 form-text">Payout Method</label>
           <div class="col-12">
             <select class="form-select" name="payout_method">
               {{ options(c.ARTIST_PAYOUT_METHOD_OPTS, app.payout_method) }}
@@ -109,8 +111,9 @@ app, c.PAGE_PATH,
 
       {% include 'art_show_applications/art_show_form.html' %}
 
+      {% if c.ART_SHOW_HAS_FEES %}
       <div class="form-group">
-        <label class="col-sm-3 control-label">Discounted Price</label>
+        <label class="col-sm-3 form-text">Discounted Price</label>
         <div class="col-sm-2">
           <input type="text" class="form-control" name="overridden_price"
                  value="{{ app.overridden_price if app.overridden_price != None else '' }}" />
@@ -124,16 +127,22 @@ app, c.PAGE_PATH,
           {% if app.status != c.APPROVED %}<br/>Attendees are only asked to pay once their applications are approved.
           {% endif %}</p>
       </div>
+      {% endif %}
 
-      <div class="form-group">
-        <label class="col-sm-3 control-label">Check-In Notes</label>
-        <div class="col-sm-6">
+      <div class="row g-sm-3">
+        <div class="col-12 col-sm-6">
+          <label class="form-text">Check-In Notes</label>
           <textarea name="check_in_notes" class="form-control" rows="4">{{ app.check_in_notes }}</textarea>
+        </div>
+        <div class="col-12 col-sm-6">
+          <label class="form-text">Agent Notes</label>
+          <textarea name="agent_notes" class="form-control" rows="4">{{ app.agent_notes }}</textarea>
+        </div>
       </div>
 
-      <div class="form-group">
-        <label class="col-sm-3 control-label">Admin Notes</label>
-        <div class="col-sm-6">
+      <div class="row mb-3 g-sm-3">
+        <div class="col-12 col-sm-6">
+          <label class="form-text">Admin Notes</label>
           <textarea name="admin_notes" class="form-control" rows="4">{{ app.admin_notes }}</textarea>
         </div>
       </div>

--- a/uber/templates/art_show_applications/art_show_form.html
+++ b/uber/templates/art_show_applications/art_show_form.html
@@ -39,7 +39,7 @@
     <select name="delivery_method" class="form-select">
       {{ options(c.ART_SHOW_DELIVERY_OPTS, app.delivery_method) }}
     </select>
-      {% if not admin_area %}
+      {% if not admin_area and c.ART_MAILING_FEE %}
       <p class="form-text">Mailing your art to the show incurs a fee of {{ c.ART_MAILING_FEE|format_currency }}.</p>
       {% endif %}
     {% endif %}
@@ -98,7 +98,7 @@
     {% else %}
       <select class="form-select" name="panels" id="panels">
         {{ int_options(0, max_panels, app.panels) }}
-      </select>({{ c.COST_PER_PANEL|format_currency }} per panel)
+      </select>{% if c.COST_PER_PANEL %}({{ c.COST_PER_PANEL|format_currency }} per panel){% endif %}
     {% endif %}
   </div>
   <div class="col-12 col-sm-6">
@@ -111,7 +111,7 @@
     {% else %}
       <select class="form-select" name="tables" id="tables">
         {{ int_options(0, max_tables, app.tables) }}
-      </select>({{ c.COST_PER_TABLE|format_currency }} per table section)
+      </select>{% if c.COST_PER_TABLE %}({{ c.COST_PER_TABLE|format_currency }} per table section){% endif %}
     {% endif %}
   </div>
 </div>
@@ -127,7 +127,7 @@
     {% else %}
       <select class="form-select" id="panels_ad" name="panels_ad">
         {{ int_options(0, max_panels, app.panels_ad) }}
-      </select>{% if not no_help_text %}({{ c.COST_PER_PANEL|format_currency }} per panel){% endif %}
+      </select>{% if c.COST_PER_PANEL %}({{ c.COST_PER_PANEL|format_currency }} per panel){% endif %}
       {% endif %}
     </div>
     <div class="col-12 col-sm-6">
@@ -140,7 +140,7 @@
       {% else %}
         <select class="form-select" name="tables_ad" id="tables_ad">
           {{ int_options(0, max_tables, app.tables_ad) }}
-        </select>{% if not no_help_text %}({{ c.COST_PER_TABLE|format_currency }} per table section){% endif %}
+        </select>{% if c.COST_PER_TABLE %}({{ c.COST_PER_TABLE|format_currency }} per table section){% endif %}
       {% endif %}
     </div>
 </div>

--- a/uber/templates/art_show_applications/confirmation.html
+++ b/uber/templates/art_show_applications/confirmation.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card">
   <div class="card-body">
-    <h2>{% if c.AFTER_ART_SHOW_WAITLIST %}You've been added to our waitlist!
+    <h2>{% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %}You've been added to our waitlist!
       {% else %}Thanks for applying for the Art Show!{% endif %}</h2>
 
     <p>We've received your application for the {{ c.EVENT_NAME }} Art Show. You applied for {{ app.panels }}
@@ -17,7 +17,7 @@
     if and when your application is approved.</p>
     {% endif %}
 
-    {% if c.AFTER_ART_SHOW_WAITLIST %}
+    {% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %}
     <p>You've been added to our waitlist, and we'll let you know if a spot opens up for you.</p>
     {% endif %}
 

--- a/uber/templates/art_show_applications/edit.html
+++ b/uber/templates/art_show_applications/edit.html
@@ -9,9 +9,6 @@
   </div>
   <div class="card-body">
     {% include 'confirm_tabs.html' with context %}
-    {% if (c.ATTRACTIONS_ENABLED and attractions) or attendee.promo_code_groups or attendee.badge_status != c.NOT_ATTENDING or attendee.marketplace_applications %}
-      {% include 'confirm_tabs.html' with context %}
-    {% endif %}
       {% if app.status == c.APPROVED %}
       Congratulations, your application has been approved!
         {% if not app.incomplete_reason and app.amount_unpaid %}

--- a/uber/templates/art_show_applications/index.html
+++ b/uber/templates/art_show_applications/index.html
@@ -30,7 +30,7 @@
     {% if c.AFTER_ART_SHOW_DEADLINE and not c.HAS_ART_SHOW_ACCESS %}
       <p>Unfortunately, the deadline for art show applications has passed and we are no longer accepting applications.</p>
     {% else %}
-      {% if c.AFTER_ART_SHOW_WAITLIST %}
+      {% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %}
         <p style="color:orange">
           The deadline for art show applications has passed. You may still submit an application to be put on our waiting
           list. Applications will close completely on {{ c.ART_SHOW_DEADLINE|datetime_local }}.
@@ -38,9 +38,12 @@
         </p>
       {% endif %}
 
-    <p>Art show applications are due by {{ c.ART_SHOW_WAITLIST|datetime_local }}. Any applications submitted after this
-    date will be automatically waitlisted. Applications will close completely on
-    {{ c.ART_SHOW_DEADLINE|datetime_local }}. Please review the {{ c.EVENT_NAME }} Art Show rules
+    <p>
+    {% if c.ART_SHOW_WAITLIST %}
+      Art show applications are due by {{ c.ART_SHOW_WAITLIST|datetime_local }}. Any applications submitted after this
+      date will be automatically waitlisted.
+    {% endif %}
+    Applications will close completely on {{ c.ART_SHOW_DEADLINE|datetime_local }}. Please review the {{ c.EVENT_NAME }} Art Show rules
     <a href="{{ c.ART_SHOW_RULES_URL }}" target="_blank">here</a>. Space is limited and may be filled prior to the application window closing.</p>
 
     <form method="post" action="index" role="form">

--- a/uber/templates/art_show_common/art_show_link.html
+++ b/uber/templates/art_show_common/art_show_link.html
@@ -12,7 +12,7 @@
           {% elif app.status == c.DECLINED %}
           Unfortunately, we were not able to accept your application.
           {% else %}
-          Your application has been approved! {% if app.is_unpaid %}Please make sure to pay before the
+          Your application has been approved! {% if c.ART_SHOW_HAS_FEES and app.is_unpaid %}Please make sure to pay before the
           deadline of {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }}.{% endif %}
           {% endif %}
           You may view your art show application
@@ -20,7 +20,7 @@
         {% endfor %}
       {% elif not admin_area %}
         You have not yet applied for the {{ c.EVENT_NAME }} art show! You may apply
-        <a href="../art_show_applications/index?attendee_id={{ attendee.id }}" target="_blank">here</a>{% if c.AFTER_ART_SHOW_WAITLIST %} to be added to the waiting list{% endif %}.
+        <a href="../art_show_applications/index?attendee_id={{ attendee.id }}" target="_blank">here</a>{% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %} to be added to the waiting list{% endif %}.
         Art show applications close on {{ c.ART_SHOW_DEADLINE|datetime_local }}.
       {% elif attendee.art_show_applications and c.HAS_ART_SHOW_ADMIN_ACCESS %}
         {% for app in attendee.art_show_applications %}

--- a/uber/templates/emails/art_show/application.html
+++ b/uber/templates/emails/art_show/application.html
@@ -36,7 +36,7 @@ confirmation link they receive by email when they register.
 {% endif %}
 
 <br/><br/>
-{% if c.AFTER_ART_SHOW_WAITLIST %}
+{% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %}
     Because our art show is currently full, your submission has been automatically placed on our waitlist.  We'll let
     you know if your application is later approved.
 {% else %}

--- a/uber/templates/emails/art_show/approved.html
+++ b/uber/templates/emails/art_show/approved.html
@@ -10,7 +10,7 @@ In order to complete your application, you must
 and pay to {% if app.attendee.badge_status == c.NEW_STATUS %}register for the convention and {% endif %}be in the art show{% endif %}
 {% elif app.attendee.amount_unpaid %}pay to be in the art show <a href="{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}">here</a>{% endif %}.
 Afterwards, y{% else %}Y{% endif %}ou can enter your artwork <a href="{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}">on this page</a>.
-{% if app.attendee.amount_unpaid %}Payment is expected by {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }} or your application may be removed and your space
+{% if c.ART_SHOW_HAS_FEES and app.attendee.amount_unpaid %}Payment is expected by {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }} or your application may be removed and your space
 filled by another applicant.{% endif %}
 
 {% if app.attendee.badge_status == c.NOT_ATTENDING %}

--- a/uber/templates/emails/art_show/reg_notification.txt
+++ b/uber/templates/emails/art_show/reg_notification.txt
@@ -1,2 +1,2 @@
-{{ app.attendee.full_name }}{% if app.artist_name %} ("{{ app.artist_name }}"){% endif %} has just applied for the Art Show{% if c.AFTER_ART_SHOW_WAITLIST %} and was automatically waitlisted{% endif %}:
+{{ app.attendee.full_name }}{% if app.artist_name %} ("{{ app.artist_name }}"){% endif %} has just applied for the Art Show{% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %} and was automatically waitlisted{% endif %}:
 {{ c.URL_BASE }}/art_show_admin/form?id={{ app.id }}


### PR DESCRIPTION
Doesn't show prices or send payment reminders if the art show is configured to have no fees. Also allows the waitlist and payment due dates to be unset.