### PR TITLE
Allow an independent art show

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -775,6 +775,11 @@ sales_tax = integer(default=1025)
 # This is printed on the artist invoice and in some reports
 commission_pct = integer(default=1000)
 
+# An option for events running just the art show plugin without using the registration system.
+# Badges are created for applicants in the "Not Attending" status, which removes requirements
+# for filling out information and prevents them from receiving attendee-related automated emails.
+independent_art_show = boolean(default=False)
+
 # Requires applicants to check a box verifying their
 # mail-in address will be in the continental US
 by_mail_us_only = boolean(default=True)

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -843,7 +843,7 @@ def us_only(app):
 
 @validation.ArtShowApplication
 def cant_ghost_art_show(app):
-    if app.attendee and app.delivery_method == c.BRINGING_IN \
+    if not c.INDEPENDENT_ART_SHOW and app.attendee and app.delivery_method == c.BRINGING_IN \
             and app.attendee.badge_status == c.NOT_ATTENDING:
         return 'You cannot bring your own art if you are not attending.'
 

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -34,10 +34,9 @@ class Root:
         if cherrypy.request.method == 'POST':
             attendee, message = session.attendee_from_art_show_app(**params)
 
-            if attendee and attendee.badge_status == c.NOT_ATTENDING \
+            if not c.INDEPENDENT_ART_SHOW and attendee and attendee.badge_status == c.NOT_ATTENDING \
                     and app.delivery_method == c.BRINGING_IN:
-                message = 'You cannot bring your own art ' \
-                          'if you are not attending.'
+                message = 'You cannot bring your own art if you are not attending.'
 
             message = message or check(attendee) or check(app, prereg=True)
             if not message:

--- a/uber/templates/art_show_applications/edit.html
+++ b/uber/templates/art_show_applications/edit.html
@@ -8,7 +8,9 @@
     Art Show Application Information
   </div>
   <div class="card-body">
-    {% include 'confirm_tabs.html' with context %}
+    {% if not c.INDEPENDENT_ART_SHOW %}
+      {% include 'confirm_tabs.html' with context %}
+    {% endif %}
       {% if app.status == c.APPROVED %}
       Congratulations, your application has been approved!
         {% if not app.incomplete_reason and app.amount_unpaid %}

--- a/uber/templates/art_show_applications/index.html
+++ b/uber/templates/art_show_applications/index.html
@@ -1,6 +1,7 @@
 {% extends "preregistration/preregbase.html" %}
 {% block title %}Art Show Application{% endblock %}
 {% block content %}
+{% if not c.INDEPENDENT_ART_SHOW %}
 <script type="text/javascript">
     var showOrHideNewBadge = function() {
         var noBadgeChecked = $.field("new_badge").prop('checked');
@@ -13,6 +14,7 @@
         $.field('new_badge').on('click', showOrHideNewBadge);
     });
 </script>
+{% endif %}
 <h2>{{ c.EVENT_NAME }} Art Show Application</h2>
 <div class="card">
   <div class="card-body">
@@ -48,6 +50,7 @@
 
     <form method="post" action="index" role="form">
       <h3>Your Information</h3>
+      {% if not c.INDEPENDENT_ART_SHOW %}
       <div class="row g-sm-3">
         <div class="col-12 col-sm-6">
           <label for="attendee_id" class="form-text">Confirmation Number</label>
@@ -73,6 +76,7 @@
           opportunity to complete your registration after submitting your application.
         </p>
       </div>
+      {% endif %}
 
       {% include 'art_show_applications/new_attendee_fields.html' %}
 

--- a/uber/templates/art_show_applications/new_attendee_fields.html
+++ b/uber/templates/art_show_applications/new_attendee_fields.html
@@ -10,10 +10,14 @@
     <label for="email" class="form-text">Email Address</label>
     <input type="email" name="email" id="email" value="{{ attendee.email }}" class="form-control" placeholder="email@example.com">
   </div>
+  {% if c.INDEPENDENT_ART_SHOW %}
+  <input type="hidden" name="not_attending" value="1">
+  {% else %}
   <div class="col-12">
     <label for="not_attending" class="form-check-label">
       <input type="checkbox" class="form-check-input" id="not_attending" name="not_attending" value="1" {% if not_attending %}checked {% endif %}/>
       I don't plan on attending {{ c.EVENT_NAME }}.
     </label>
   </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
Adds a config setting that lets you run an art show without talking about badges. While badges still need to be created in the backend, the attendee doesn't see their badge and we use the existing "Not Attending" status to make sure they don't qualify for emails or are charged any money.