### PR TITLE
Pin service versions in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,6 @@ services:
       - POSTGRES_PASSWORD=uber_db
       - POSTGRES_USER=uber_db
       - POSTGRES_DB=uber_db
-    ports:
-      - 5432:5432
     volumes:
       - postgres_data:/var/lib/postgresql
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,17 +36,21 @@ services:
     <<: *uber
     command: ['celery-worker']
   db:
-    image: postgres
+    image: postgres:18.4-alpine
     environment:
       - POSTGRES_PASSWORD=uber_db
       - POSTGRES_USER=uber_db
       - POSTGRES_DB=uber_db
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres_data:/var/lib/postgresql
   redis:
-    image: redis
+    image: redis:8.8-m03
   rabbitmq:
     ports:
       - "5672"
-    image: rabbitmq:alpine
+    image: rabbitmq:4.2-alpine 
     environment:
       - RABBITMQ_DEFAULT_USER=celery
       - RABBITMQ_DEFAULT_PASS=celery
@@ -68,7 +72,7 @@ services:
       - 5555:5555
     profiles: ["dev"]
   nginx:
-    image: nginx
+    image: nginx:1.30.1-alpine
     volumes:
       - ./dev-nginx.conf:/etc/nginx/conf.d/default.conf
       - ./ssl-key.pem:/root/ssl/key.pem
@@ -78,3 +82,6 @@ services:
     depends_on:
       - web
     profiles: ["ssl"]
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
This change pins specific versions in the RAMS docker-compose.yaml file. Keeping versions to `latest` invites some unexpected and difficult-to-diagnose issues when these services introduce breaking changes.

We want to control when version updates happen.